### PR TITLE
bump clearpath_socketcan_interface to C++17 to solve std::filesystem not declared error.

### DIFF
--- a/clearpath_socketcan_interface/CMakeLists.txt
+++ b/clearpath_socketcan_interface/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 project(clearpath_socketcan_interface)
 
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_STANDARD 14)
+  #set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17) # std::filesystems fails without C++ 17
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/clearpath_socketcan_interface/package.xml
+++ b/clearpath_socketcan_interface/package.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>clearpath_socketcan_interface</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <description>Clearpath's CAN interface description with helpers for filtering and driver implementation. Further a socketcan implementation based on boost::asio is included.</description>
 
   <maintainer email="lcamero@clearpathrobotics.com">Luis Camero</maintainer>
+  <!-- Version 1.0.2 -->
+  <maintainer email="azmyin12@gmail.com">Azmyin Md. Kamal</maintainer>
 
   <license>LGPLv3</license>
 
@@ -13,6 +15,7 @@
 
   <author email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</author>
 
+  
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>boost</depend>


### PR DESCRIPTION
Solves #21 